### PR TITLE
kaitai: fix infinite recursion in ReadBitsInt

### DIFF
--- a/kaitai/stream.go
+++ b/kaitai/stream.go
@@ -300,7 +300,7 @@ func (k *Stream) ReadBitsInt(totalBitsNeeded uint8) (val uint64, err error) {
 
 		// define how many bits should be read
 		readBits := totalBitsNeeded % 8
-		if totalBitsNeeded == 8 {
+		if totalBitsNeeded%8 == 0 {
 			readBits = 8
 		}
 


### PR DESCRIPTION
If totalBitsNeeded was larger than 8 and still an even multiple of 8
bits, then readBits would be 0, causing an infinite recursion.