### PR TITLE
Fix ReadBytesTerm() method

### DIFF
--- a/kaitai/stream.go
+++ b/kaitai/stream.go
@@ -246,11 +246,16 @@ func (k *Stream) ReadBytesPadTerm(size int, term, pad byte, includeTerm bool) ([
 // errors result in an error.
 func (k *Stream) ReadBytesTerm(term byte, includeTerm, consumeTerm, eosError bool) ([]byte, error) {
 	r := bufio.NewReader(k)
+	pos, err := k.Pos()
+	if err != nil {
+		return []byte {}, err
+	}
 	slice, err := r.ReadBytes(term)
 
 	if err != nil && (err != io.EOF || eosError) {
 		return slice, err
 	}
+	k.Seek(pos + int64(len(slice)), io.SeekStart)
 	if !includeTerm {
 		slice = slice[:len(slice)-1]
 	}


### PR DESCRIPTION
The ReadBytesTerm() call caused seeking the `Stream` to the end, which led to instant EOF error when trying to read the next `seq` field in `Read` method. So I store the current stream position before the seeking happens and then seek to the correct one.

Merging this will fix a series of tests, namely `ExprArray`, `ExprIoPos`, `RepeatNStrzDouble`, `RepeatNStrz`, `StrCombine`, `TermBytes` and `TermStrz`.

However, I'm a bit hesitant to commit it myself because I haven't much experience with Go.