### PR TITLE
Fix linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - bodyclose
     - contextcheck
     - cyclop
-    - deadcode
     # - depguard
     - dogsled
     - dupl
@@ -45,7 +44,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - ireturn
@@ -67,7 +65,6 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     - tagliatelle
     - tenv
@@ -78,7 +75,6 @@ linters:
     - unconvert
     - unparam
     - unused
-    - varcheck
     # - varnamelen
     - wastedassign
     - whitespace

--- a/kaitai/error.go
+++ b/kaitai/error.go
@@ -62,7 +62,8 @@ type ValidationNotEqualError struct {
 }
 
 // NewValidationNotEqualError creates a new ValidationNotEqualError instance.
-func NewValidationNotEqualError(expected interface{}, actual interface{}, io *Stream, srcPath string) ValidationNotEqualError {
+func NewValidationNotEqualError(
+	expected interface{}, actual interface{}, io *Stream, srcPath string) ValidationNotEqualError {
 	return ValidationNotEqualError{
 		expected,
 		actual,
@@ -93,7 +94,8 @@ type ValidationLessThanError struct {
 }
 
 // NewValidationLessThanError creates a new ValidationLessThanError instance.
-func NewValidationLessThanError(min interface{}, actual interface{}, io *Stream, srcPath string) ValidationLessThanError {
+func NewValidationLessThanError(
+	min interface{}, actual interface{}, io *Stream, srcPath string) ValidationLessThanError {
 	return ValidationLessThanError{
 		min,
 		actual,
@@ -124,7 +126,8 @@ type ValidationGreaterThanError struct {
 }
 
 // NewValidationGreaterThanError creates a new ValidationGreaterThanError instance.
-func NewValidationGreaterThanError(max interface{}, actual interface{}, io *Stream, srcPath string) ValidationGreaterThanError {
+func NewValidationGreaterThanError(
+	max interface{}, actual interface{}, io *Stream, srcPath string) ValidationGreaterThanError {
 	return ValidationGreaterThanError{
 		max,
 		actual,

--- a/kaitai/stream.go
+++ b/kaitai/stream.go
@@ -14,6 +14,13 @@ import (
 // APIVersion defines the currently used API version.
 const APIVersion = 0x0001
 
+// ErrInvalidSizeRequested is returned when KaitaiStream methods are called
+// with a size argument which does not make sense:
+//
+// - ReadBytes with negative number of bytes
+// - ReadBitsIntBe/Le with more than 8 bytes
+var ErrInvalidSizeRequested = errors.New("invalid size requested")
+
 // A Stream represents a sequence of bytes. It encapsulates reading from files
 // and memory, stores pointer to its current position, and allows
 // reading/writing of various primitives.
@@ -220,7 +227,7 @@ func (k *Stream) ReadF8le() (v float64, err error) {
 // ReadBytes reads n bytes and returns those as a byte array.
 func (k *Stream) ReadBytes(n int) (b []byte, err error) {
 	if n < 0 {
-		return nil, fmt.Errorf("ReadBytes(%d): negative number of bytes to read", n)
+		return nil, fmt.Errorf("ReadBytes(%d): %w", n, ErrInvalidSizeRequested)
 	}
 
 	b = make([]byte, n)
@@ -336,7 +343,7 @@ func (k *Stream) ReadBitsIntBe(n int) (res uint64, err error) {
 		// 9 bits => 2 bytes
 		bytesNeeded := ((bitsNeeded - 1) / 8) + 1 // `ceil(bitsNeeded / 8)`
 		if bytesNeeded > 8 {
-			return res, fmt.Errorf("ReadBitsIntBe(%d): more than 8 bytes requested", n)
+			return res, fmt.Errorf("ReadBitsIntBe(%d): more than 8 bytes requested: %w", n, ErrInvalidSizeRequested)
 		}
 		_, err = k.Read(k.buf[:bytesNeeded])
 		if err != nil {
@@ -377,7 +384,7 @@ func (k *Stream) ReadBitsIntLe(n int) (res uint64, err error) {
 		// 9 bits => 2 bytes
 		bytesNeeded := ((bitsNeeded - 1) / 8) + 1 // `ceil(bitsNeeded / 8)`
 		if bytesNeeded > 8 {
-			return res, fmt.Errorf("ReadBitsIntLe(%d): more than 8 bytes requested", n)
+			return res, fmt.Errorf("ReadBitsIntLe(%d): more than 8 bytes requested: %w", n, ErrInvalidSizeRequested)
 		}
 		_, err = k.Read(k.buf[:bytesNeeded])
 		if err != nil {

--- a/kaitai/stream.go
+++ b/kaitai/stream.go
@@ -305,24 +305,6 @@ func (k *Stream) ReadBytesTerm(term byte, includeTerm, consumeTerm, eosError boo
 	return slice, nil
 }
 
-// ReadStrEOS reads the remaining bytes as a string.
-func (k *Stream) ReadStrEOS(encoding string) (string, error) {
-	buf, err := ioutil.ReadAll(k)
-
-	// Go's string type can contain any bytes.  The Go `range` operator
-	// assumes that the encoding is UTF-8 and some standard Go libraries
-	// also would like UTF-8.  For now we'll leave any advanced
-	// conversions up to the user.
-	return string(buf), err
-}
-
-// ReadStrByteLimit reads limit number of bytes and returns those as a string.
-func (k *Stream) ReadStrByteLimit(limit int, encoding string) (string, error) {
-	buf := make([]byte, limit)
-	n, err := k.Read(buf)
-	return string(buf[:n]), err
-}
-
 // AlignToByte discards the remaining bits and starts reading bits at the
 // next byte.
 func (k *Stream) AlignToByte() {
@@ -407,9 +389,4 @@ func (k *Stream) ReadBitsIntLe(n int) (res uint64, err error) {
 	var mask uint64 = (1 << n) - 1 // unlike some other languages, no problem with this in Go
 	res &= mask
 	return res, nil
-}
-
-// ReadBitsArray is not implemented yet.
-func (k *Stream) ReadBitsArray(n uint) error {
-	return nil // TODO: implement
 }

--- a/kaitai/stream.go
+++ b/kaitai/stream.go
@@ -87,7 +87,7 @@ func (k *Stream) Pos() (int64, error) {
 // ReadU1 reads 1 byte and returns this as uint8.
 func (k *Stream) ReadU1() (v uint8, err error) {
 	if _, err = k.Read(k.buf[:1]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU1: error reading 1 byte: %w", err)
 	}
 	return k.buf[0], nil
 }
@@ -95,7 +95,7 @@ func (k *Stream) ReadU1() (v uint8, err error) {
 // ReadU2be reads 2 bytes in big-endian order and returns those as uint16.
 func (k *Stream) ReadU2be() (v uint16, err error) {
 	if _, err = k.Read(k.buf[:2]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU2be: error reading 2 bytes: %w", err)
 	}
 	return binary.BigEndian.Uint16(k.buf[:2]), nil
 }
@@ -103,7 +103,7 @@ func (k *Stream) ReadU2be() (v uint16, err error) {
 // ReadU4be reads 4 bytes in big-endian order and returns those as uint32.
 func (k *Stream) ReadU4be() (v uint32, err error) {
 	if _, err = k.Read(k.buf[:4]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU4be: error reading 4 bytes: %w", err)
 	}
 	return binary.BigEndian.Uint32(k.buf[:4]), nil
 }
@@ -111,7 +111,7 @@ func (k *Stream) ReadU4be() (v uint32, err error) {
 // ReadU8be reads 8 bytes in big-endian order and returns those as uint64.
 func (k *Stream) ReadU8be() (v uint64, err error) {
 	if _, err = k.Read(k.buf[:8]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU8be: error reading 8 bytes: %w", err)
 	}
 	return binary.BigEndian.Uint64(k.buf[:8]), nil
 }
@@ -119,7 +119,7 @@ func (k *Stream) ReadU8be() (v uint64, err error) {
 // ReadU2le reads 2 bytes in little-endian order and returns those as uint16.
 func (k *Stream) ReadU2le() (v uint16, err error) {
 	if _, err = k.Read(k.buf[:2]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU2le: error reading 2 bytes: %w", err)
 	}
 	return binary.LittleEndian.Uint16(k.buf[:2]), nil
 }
@@ -127,7 +127,7 @@ func (k *Stream) ReadU2le() (v uint16, err error) {
 // ReadU4le reads 4 bytes in little-endian order and returns those as uint32.
 func (k *Stream) ReadU4le() (v uint32, err error) {
 	if _, err = k.Read(k.buf[:4]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU4le: error reading 4 bytes: %w", err)
 	}
 	return binary.LittleEndian.Uint32(k.buf[:4]), nil
 }
@@ -135,7 +135,7 @@ func (k *Stream) ReadU4le() (v uint32, err error) {
 // ReadU8le reads 8 bytes in little-endian order and returns those as uint64.
 func (k *Stream) ReadU8le() (v uint64, err error) {
 	if _, err = k.Read(k.buf[:8]); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("ReadU8le: error reading 8 bytes: %w", err)
 	}
 	return binary.LittleEndian.Uint64(k.buf[:8]), nil
 }
@@ -214,12 +214,19 @@ func (k *Stream) ReadBytes(n int) (b []byte, err error) {
 
 	b = make([]byte, n)
 	_, err = io.ReadFull(k, b)
-	return b, err
+	if err != nil {
+		return nil, fmt.Errorf("ReadBytes: error reading %d bytes: %w", n, err)
+	}
+	return b, nil
 }
 
 // ReadBytesFull reads all remaining bytes and returns those as a byte array.
 func (k *Stream) ReadBytesFull() ([]byte, error) {
-	return ioutil.ReadAll(k)
+	res, err := ioutil.ReadAll(k)
+	if err != nil {
+		return nil, fmt.Errorf("ReadBytesFull: error reading all bytes: %w", err)
+	}
+	return res, nil
 }
 
 // ReadBytesPadTerm reads up to size bytes. pad bytes are discarded. It
@@ -319,7 +326,7 @@ func (k *Stream) ReadBitsIntBe(n int) (res uint64, err error) {
 		}
 		_, err = k.Read(k.buf[:bytesNeeded])
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("ReadBitsIntBe(%d): %w", n, err)
 		}
 		for i := 0; i < bytesNeeded; i++ {
 			res = res<<8 | uint64(k.buf[i])
@@ -335,7 +342,7 @@ func (k *Stream) ReadBitsIntBe(n int) (res uint64, err error) {
 	var mask uint64 = (1 << k.bitsLeft) - 1 // `bitsLeft` is in range 0..7
 	k.bits &= mask
 
-	return res, err
+	return res, nil
 }
 
 // ReadBitsInt reads n-bit integer in big-endian byte order and returns it as uint64.
@@ -360,7 +367,7 @@ func (k *Stream) ReadBitsIntLe(n int) (res uint64, err error) {
 		}
 		_, err = k.Read(k.buf[:bytesNeeded])
 		if err != nil {
-			return res, err
+			return res, fmt.Errorf("ReadBitsIntLe(%d): %w", n, err)
 		}
 		for i := 0; i < bytesNeeded; i++ {
 			res |= uint64(k.buf[i]) << (i * 8)
@@ -378,7 +385,7 @@ func (k *Stream) ReadBitsIntLe(n int) (res uint64, err error) {
 
 	var mask uint64 = (1 << n) - 1 // unlike some other languages, no problem with this in Go
 	res &= mask
-	return res, err
+	return res, nil
 }
 
 // ReadBitsArray is not implemented yet.

--- a/kaitai/stream_test.go
+++ b/kaitai/stream_test.go
@@ -771,45 +771,31 @@ func TestStream_ReadBitsIntBe(t *testing.T) {
 		{"ReadBitsIntBe", NewStream(bytes.NewReader([]byte{0xF0})), args{5}, 0x1E, false},
 		{"ReadBitsIntBe", NewStream(bytes.NewReader([]byte{0x12, 0x34, 0x56, 0xFF})), args{24}, 0x123456, false},
 		{"ReadBitsIntBe", NewStream(bytes.NewReader([]byte{0xAB, 0xC7})), args{12}, 0xABC, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotVal, err := tt.k.ReadBitsIntBe(tt.args.totalBitsNeeded)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Stream.ReadBitsIntBe() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if gotVal != tt.wantVal {
-				t.Errorf("Stream.ReadBitsIntBe() = %v, want %v", gotVal, tt.wantVal)
-			}
-		})
-	}
-}
-
-func TestStream_ReadBitsIntLe(t *testing.T) {
-	type args struct {
-		n int
-	}
-	tests := []struct {
-		name    string
-		k       *Stream
-		args    args
-		wantRes uint64
-		wantErr bool
-	}{
 		{"ReadBitsIntLe", NewStream(bytes.NewReader([]byte{0xF0})), args{5}, 16, false},
 		{"ReadBitsIntLe", NewStream(bytes.NewReader([]byte{0x56, 0x34, 0x12, 0xFF})), args{24}, 0x123456, false},
 		{"ReadBitsIntLe", NewStream(bytes.NewReader([]byte{0xBC, 0x7A})), args{12}, 0xABC, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotRes, err := tt.k.ReadBitsIntLe(tt.args.n)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Stream.ReadBitsIntLe() error = %v, wantErr %v", err, tt.wantErr)
+			var gotVal uint64
+			var err error
+
+			switch tt.name {
+			case "ReadBitsIntBe":
+				gotVal, err = tt.k.ReadBitsIntBe(tt.args.totalBitsNeeded)
+			case "ReadBitsIntLe":
+				gotVal, err = tt.k.ReadBitsIntLe(tt.args.totalBitsNeeded)
+			default:
+				t.Errorf("Unknown test method: %v", tt.name)
 				return
 			}
-			if gotRes != tt.wantRes {
-				t.Errorf("Stream.ReadBitsIntLe() = %v, want %v", gotRes, tt.wantRes)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Stream.%s() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+				return
+			}
+			if gotVal != tt.wantVal {
+				t.Errorf("Stream.%s() = %v, want %v", tt.name, gotVal, tt.wantVal)
 			}
 		})
 	}

--- a/kaitai/stream_test.go
+++ b/kaitai/stream_test.go
@@ -650,61 +650,6 @@ func TestStream_ReadBytesTerm(t *testing.T) {
 	}
 }
 
-func TestStream_ReadStrEOS(t *testing.T) {
-	type args struct {
-		encoding string
-	}
-	tests := []struct {
-		name    string
-		k       *Stream
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{"ReadStrEOS", NewStream(bytes.NewReader([]byte("fooo"))), args{""}, "fooo", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.k.ReadStrEOS(tt.args.encoding)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Stream.ReadStrEOS() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("Stream.ReadStrEOS() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestStream_ReadStrByteLimit(t *testing.T) {
-	type args struct {
-		limit    int
-		encoding string
-	}
-	tests := []struct {
-		name    string
-		k       *Stream
-		args    args
-		want    string
-		wantErr bool
-	}{
-		{"ReadStrByteLimit", NewStream(bytes.NewReader([]byte("fooo"))), args{2, ""}, "fo", false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.k.ReadStrByteLimit(tt.args.limit, tt.args.encoding)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("Stream.ReadStrByteLimit() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("Stream.ReadStrByteLimit() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestStream_AlignToByte(t *testing.T) {
 	type bitInt struct {
 		bits           int
@@ -757,7 +702,7 @@ func TestStream_AlignToByte(t *testing.T) {
 	}
 }
 
-func TestStream_ReadBitsIntBe(t *testing.T) {
+func TestStream_ReadBitsInt(t *testing.T) {
 	type args struct {
 		totalBitsNeeded int
 	}
@@ -796,27 +741,6 @@ func TestStream_ReadBitsIntBe(t *testing.T) {
 			}
 			if gotVal != tt.wantVal {
 				t.Errorf("Stream.%s() = %v, want %v", tt.name, gotVal, tt.wantVal)
-			}
-		})
-	}
-}
-
-func TestStream_ReadBitsArray(t *testing.T) {
-	type args struct {
-		n uint
-	}
-	tests := []struct {
-		name    string
-		k       *Stream
-		args    args
-		wantErr bool
-	}{
-		// TODO: Add test cases.
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if err := tt.k.ReadBitsArray(tt.args.n); (err != nil) != tt.wantErr {
-				t.Errorf("Stream.ReadBitsArray() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/kaitai/util.go
+++ b/kaitai/util.go
@@ -3,6 +3,7 @@ package kaitai
 import (
 	"bytes"
 	"compress/zlib"
+	"fmt"
 	"io/ioutil"
 	"math/bits"
 
@@ -43,19 +44,23 @@ func ProcessZlib(in []byte) ([]byte, error) {
 	// we could reuse it by using a sync.Pool if this is called in a tight loop.
 	r, err := zlib.NewReader(b)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("ProcessZlib: error initializing zlib reader: %w", err)
 	}
 
-	return ioutil.ReadAll(r)
+	res, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("ProcessZlib: error reading zlib data: %w", err)
+	}
+	return res, nil
 }
 
 // BytesToStr returns a string decoded by the given decoder.
 func BytesToStr(in []byte, decoder *encoding.Decoder) (string, error) {
 	i := bytes.NewReader(in)
 	o := transform.NewReader(i, decoder)
-	d, e := ioutil.ReadAll(o)
-	if e != nil {
-		return "", e
+	d, err := ioutil.ReadAll(o)
+	if err != nil {
+		return "", fmt.Errorf("BytesToStr: error reading all: %w", err)
 	}
 	return string(d), nil
 }

--- a/kaitai/writer.go
+++ b/kaitai/writer.go
@@ -2,6 +2,7 @@ package kaitai
 
 import (
 	"encoding/binary"
+	"fmt"
 	"io"
 	"math"
 )
@@ -21,49 +22,70 @@ func NewWriter(w io.Writer) *Writer {
 func (k *Writer) WriteU1(v uint8) error {
 	k.buf[0] = v
 	_, err := k.Write(k.buf[:1])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU1: failed to write uint8: %w", err)
+	}
+	return nil
 }
 
 // WriteU2be writes a uint16 in big-endian order to the underlying writer.
 func (k *Writer) WriteU2be(v uint16) error {
 	binary.BigEndian.PutUint16(k.buf[:2], v)
 	_, err := k.Write(k.buf[:2])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU2be: failed to write uint16: %w", err)
+	}
+	return nil
 }
 
 // WriteU4be writes a uint32 in big-endian order to the underlying writer.
 func (k *Writer) WriteU4be(v uint32) error {
 	binary.BigEndian.PutUint32(k.buf[:4], v)
 	_, err := k.Write(k.buf[:4])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU4be: failed to write uint32: %w", err)
+	}
+	return nil
 }
 
 // WriteU8be writes a uint64 in big-endian order to the underlying writer.
 func (k *Writer) WriteU8be(v uint64) error {
 	binary.BigEndian.PutUint64(k.buf[:8], v)
 	_, err := k.Write(k.buf[:8])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU8be: failed to write uint64: %w", err)
+	}
+	return nil
 }
 
 // WriteU2le writes a uint16 in little-endian order to the underlying writer.
 func (k *Writer) WriteU2le(v uint16) error {
 	binary.LittleEndian.PutUint16(k.buf[:2], v)
 	_, err := k.Write(k.buf[:2])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU2le: failed to write uint16: %w", err)
+	}
+	return nil
 }
 
 // WriteU4le writes a uint32 in little-endian order to the underlying writer.
 func (k *Writer) WriteU4le(v uint32) error {
 	binary.LittleEndian.PutUint32(k.buf[:4], v)
 	_, err := k.Write(k.buf[:4])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU4le: failed to write uint32: %w", err)
+	}
+	return nil
 }
 
 // WriteU8le writes a uint64 in little-endian order to the underlying writer.
 func (k *Writer) WriteU8le(v uint64) error {
 	binary.LittleEndian.PutUint64(k.buf[:8], v)
 	_, err := k.Write(k.buf[:8])
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteU8le: failed to write uint64: %w", err)
+	}
+	return nil
 }
 
 // WriteS1 writes an int8 to the underlying writer.
@@ -124,5 +146,8 @@ func (k *Writer) WriteF8le(v float64) error {
 // WriteBytes writes the byte slice b to the underlying writer.
 func (k *Writer) WriteBytes(b []byte) error {
 	_, err := k.Write(b)
-	return err
+	if err != nil {
+		return fmt.Errorf("WriteBytes: failed to write bytes: %w", err)
+	}
+	return nil
 }


### PR DESCRIPTION
After upgrade of Go / golangci-lint, a few new errors popped up. This PR attempts to fix them.

- Disable unsupported linters
- Fix problems with line lengths
- Fix error comparison with modern one using errors.Is()
- Wrap errors to fix some linter problems
- kaitai/stream.go: fix rest of wrapping errors
- kaitai/util.go: fix error wrapping problems
- kaitai/writer.go: fix wrapping problems
- kaitai/stream.go: fix traceless messages for invalid size requested
- Rewrite TestStream_ReadBitsIntBe + TestStream_ReadBitsIntLe to avoid duplication
- Remove unused/obsolete functions and tests for them: ReadStrEOS, ReadStrByteLimit, ReadBitsArray