### PR TITLE
Fix ReadBytesTerm incorrectly stripping last byte on EOF

### DIFF
--- a/kaitai/stream.go
+++ b/kaitai/stream.go
@@ -316,11 +316,19 @@ func (k *Stream) ReadBytesTerm(term byte, includeTerm, consumeTerm, eosError boo
 	slice, err := r.ReadBytes(term)
 
 	if err != nil {
-		// If eosError if false, ignore io.EOF and bail out on any other error
+		// If eosError is false, ignore io.EOF and bail out on any other error
 		// If eosError is true, bail out on any error, including io.EOF
 		if eosError || !errors.Is(err, io.EOF) {
 			return slice, fmt.Errorf("ReadBytesTerm: error reading bytes until term byte: %w", err)
 		}
+		// EOF reached without finding the terminator. Return the data as-is.
+		// Do not strip the last byte (no terminator to exclude) and do not
+		// seek back (no terminator to "unconsume").
+		_, seekErr := k.ReadSeeker.Seek(pos+int64(len(slice)), io.SeekStart)
+		if seekErr != nil {
+			return []byte{}, fmt.Errorf("ReadBytesTerm: error seeking: %w", seekErr)
+		}
+		return slice, nil
 	}
 	_, err = k.ReadSeeker.Seek(pos+int64(len(slice)), io.SeekStart)
 	if err != nil {

--- a/kaitai/stream_test.go
+++ b/kaitai/stream_test.go
@@ -635,6 +635,12 @@ func TestStream_ReadBytesTerm(t *testing.T) {
 		{"ReadBytesTerm", NewStream(bytes.NewReader([]byte("fooo"))), args{'o', false, true, true}, []byte("f"), false},
 		{"ReadBytesTerm", NewStream(bytes.NewReader([]byte("fooo"))), args{'o', true, false, true}, []byte("fo"), false},
 		{"ReadBytesTerm", NewStream(bytes.NewReader([]byte("fooo"))), args{'o', true, true, true}, []byte("fo"), false},
+		{"ReadBytesTerm EOF no term", NewStream(bytes.NewReader([]byte("abc"))), args{'x', false, false, false}, []byte("abc"), false},
+		{"ReadBytesTerm EOF no term includeTerm", NewStream(bytes.NewReader([]byte("abc"))), args{'x', true, false, false}, []byte("abc"), false},
+		{"ReadBytesTerm EOF no term consumeTerm", NewStream(bytes.NewReader([]byte("abc"))), args{'x', false, true, false}, []byte("abc"), false},
+		{"ReadBytesTerm EOF no term both", NewStream(bytes.NewReader([]byte("abc"))), args{'x', true, true, false}, []byte("abc"), false},
+		{"ReadBytesTerm EOF no term eosError", NewStream(bytes.NewReader([]byte("abc"))), args{'x', false, false, true}, []byte("abc"), true},
+		{"ReadBytesTerm EOF empty stream", NewStream(bytes.NewReader([]byte{})), args{'x', false, false, false}, []byte{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
When `ReadBytesTerm` reaches end-of-stream without finding the terminator byte (with `eosError=false`), it should return all bytes read. Previously, it unconditionally applied `includeTerm`/`consumeTerm` logic to the result, which caused two problems:

1. The last byte of actual data was stripped (as if it were a terminator)
2. A seek-back was performed (as if there were a terminator to "unconsume")

This can be triggered by any .ksy struct that uses:

```yaml
seq:
  - id: body
    terminator: 0
    eos-error: false
```

...when the input data does not contain the terminator byte.

The Java runtime handles this correctly by returning immediately when EOF is reached, without modifying the accumulated buffer:

```java
// ByteBufferKaitaiStream.java, readBytesTerm()
if (!bb.hasRemaining()) {
    if (eosError) {
        throw new RuntimeException("...");
    }
    return buf.toByteArray();  // no stripping, no seeking
}
```

The fix separates the EOF path from the terminator-found path, so that `includeTerm` and `consumeTerm` only take effect when a terminator was actually encountered.

This makes `TestTermBytes4`, `TestTermStruct4` and `TestTermStrz4` pass with Go.